### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -12,7 +12,7 @@ const Header = () => {
   return (
     <header className="z-[999] relative">
       <motion.div
-        className="flex fixed top-0 rounded-none border border-white dark:border-black/40 border-opacity-40 bg-gray-50 dark:bg-gray-950 bg-opacity-80 dark:bg-opacity-75 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6  sm:rounded-full left-1/2"
+        className="flex fixed top-0 left-1/2 w-[95%] sm:w-max px-2 sm:px-0 rounded-none border border-white dark:border-black/40 border-opacity-40 bg-gray-50 dark:bg-gray-950 bg-opacity-80 dark:bg-opacity-75 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6 sm:rounded-full"
         initial={{ y: -100, x: "-50%", opacity: 0 }}
         animate={{ y: 0, x: "-50%", opacity: 1 }}>
         <nav className="">

--- a/app/components/section-title.tsx
+++ b/app/components/section-title.tsx
@@ -8,7 +8,7 @@ type SectionTitleProps = {
 const SectionTitle = ({ children }: SectionTitleProps) => {
   return (
     <motion.h2
-      className="text-3xl font-medium capitalize mb-8"
+      className="text-2xl sm:text-3xl font-medium capitalize mb-8"
       initial={{ opacity: 0, y: 100 }}
       whileInView={{ opacity: 1, y: 0, transition: { delay: 0.2 } }}
       viewport={{ once: true }}>

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -9,7 +9,7 @@ type AboutSectionProps = {
 };
 const AboutSection = ({ data }: AboutSectionProps) => {
   return (
-    <PortfolioSection id="#about">
+    <PortfolioSection id="#about" className="px-4">
       <SectionTitle>About me</SectionTitle>
       <motion.p
         className="font-medium"

--- a/app/components/sections/experience-section.tsx
+++ b/app/components/sections/experience-section.tsx
@@ -23,7 +23,7 @@ const ExperienceSection = ({ data }: ExperienceSectionProps) => {
   return (
     <PortfolioSection
       id={"#experience"}
-      className="pt-28 w-[80%]"
+      className="pt-28 px-4 w-full sm:w-[80%]"
       maxWidth="100%">
       <SectionTitle>Experiences</SectionTitle>
       <VerticalTimeline lineColor="#f3f4f6">

--- a/app/components/sections/intro-section.tsx
+++ b/app/components/sections/intro-section.tsx
@@ -13,9 +13,9 @@ type IntroSectionProps = {
 };
 const IntroSection = ({ myData, data }: IntroSectionProps) => {
   return (
-    <PortfolioSection id="#home">
-      <div className="flex items-center justify-center">
-        <div className="relative">
+    <PortfolioSection id="#home" className="px-4">
+      <div className="flex flex-col items-center sm:flex-row sm:items-start gap-6 sm:gap-8">
+        <div className="relative mx-auto">
           <motion.div
             initial={{ opacity: 0, scale: 0 }}
             animate={{ opacity: 1, scale: 1 }}
@@ -40,21 +40,21 @@ const IntroSection = ({ myData, data }: IntroSectionProps) => {
             👋
           </motion.span>
         </div>
+        <motion.h1
+          className="font-medium text-2xl text-center sm:text-left"
+          initial={{ opacity: 0, y: 100 }}
+          animate={{ opacity: 1, y: 0 }}>
+          <p className="font-bold text-3xl my-8">{data.p1}</p>
+          <p>
+            {data.p2}
+            <span className="font-bold">{data.p3}</span>
+            {data.p4}
+            <span className="font-bold">{data.p5}</span>
+            {data.p6}
+            <span className="font-bold">{data.p7}</span>
+          </p>
+        </motion.h1>
       </div>
-      <motion.h1
-        className="font-medium text-2xl"
-        initial={{ opacity: 0, y: 100 }}
-        animate={{ opacity: 1, y: 0 }}>
-        <p className="font-bold text-3xl my-8">{data.p1}</p>
-        <p>
-          {data.p2}
-          <span className="font-bold">{data.p3}</span>
-          {data.p4}
-          <span className="font-bold">{data.p5}</span>
-          {data.p6}
-          <span className="font-bold">{data.p7}</span>
-        </p>
-      </motion.h1>
       <motion.div
         initial={{ opacity: 0, y: 100 }}
         animate={{ opacity: 1, y: 0 }}

--- a/app/components/sections/projects-section.tsx
+++ b/app/components/sections/projects-section.tsx
@@ -11,9 +11,9 @@ type ProjectsSectionProps = {
 };
 const ProjectsSection = ({ data }: ProjectsSectionProps) => {
   return (
-    <PortfolioSection id="#projects" maxWidth="100%">
+    <PortfolioSection id="#projects" className="px-4" maxWidth="100%">
       <SectionTitle>Projects</SectionTitle>
-      <div className="flex gap-5">
+      <div className="flex flex-col items-center gap-5 sm:flex-row sm:flex-wrap">
         {data.projects.map((project) => (
           <ProjectCard key={project.id} data={project} />
         ))}

--- a/app/components/sections/skills-section.tsx
+++ b/app/components/sections/skills-section.tsx
@@ -12,7 +12,7 @@ const SkillsSection = ({ data }: SkillsSectionProps) => {
   const [selectedSkill, setSelectedSkill] = useState("All");
 
   return (
-    <PortfolioSection id={"#skills"}>
+    <PortfolioSection id={"#skills"} className="px-4">
       <SectionTitle>Skills</SectionTitle>
       <h3 className="text-left w-full py-2 text-xl">Core </h3>
       <div className="flex flex-wrap gap-2  w-full">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
           name="google-site-verification"
           content="wh27ZUsn1uIf_GnrLVDe1F_WK31v6hpO7MtdV9SZEow"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default async function Home() {
   const sections = sectionsData; // await getMyInfo();
 
   return (
-    <main className="flex flex-col items-center">
+    <main className="flex flex-col items-center px-2 sm:px-0">
       <IntroSection
         myData={sections.my_data}
         data={sections.intro.data as Record<string, string>}


### PR DESCRIPTION
## Summary
- make header and layout responsive for small screens
- adjust section widths and add horizontal padding
- tweak responsive typography

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e7618a1f08332bc53a35c144f55a5